### PR TITLE
Legger til metadata på navneoppslag mot PDL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
     testImplementation("org.assertj:assertj-core:$assertJVersion")
     testImplementation("io.ktor:ktor-client-mock-jvm:$ktorVersion")
+    testImplementation("io.ktor:ktor-client-apache:$ktorVersion") // Brukes i integrasjonstester
+
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
 }

--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/RestSTSClient.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/RestSTSClient.kt
@@ -47,7 +47,6 @@ class RestStsClientImpl(username: String,
         return currentToken.tokenAsString
     }
 
-
     private fun requestToken(): JwtToken {
         val response = runBlocking {
             httpClient.get<STSOidcResponse>(endpointURI) {

--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/pdl/PdlClient.kt
@@ -28,15 +28,11 @@ class PdlClientImpl(
         private val httpClient: HttpClient,
         private val om: ObjectMapper
 ) : PdlClient {
-    private val query = this::class.java.getResource("/pdl/hentPerson.graphql").readText().replace(Regex("[\n\r]"), "")
-
-    init {
-        LOG.debug("Query: $query")
-    }
-
+    private val personNavnQuery = this::class.java.getResource("/pdl/hentPersonNavn.graphql").readText().replace(Regex("[\n\r]"), "")
+    
     override fun person(ident: String): PdlPerson? {
         val stsToken = stsClient.getOidcToken()
-        val entity = PdlRequest(query, Variables(ident))
+        val entity = PdlRequest(personNavnQuery, Variables(ident))
         val pdlPersonReponse = runBlocking {
             httpClient.post<PdlPersonResponse> {
                 url(pdlUrl)
@@ -53,6 +49,8 @@ class PdlClientImpl(
 
         return pdlPersonReponse.data?.hentPerson
     }
+
+
 
     companion object {
         private val LOG = LoggerFactory.getLogger(PdlClient::class.java)

--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/pdl/PdlRequests.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/pdl/PdlRequests.kt
@@ -6,6 +6,5 @@ data class PdlRequest(
 )
 
 data class Variables(
-        val ident: String,
-        val navnHistorikk: Boolean = false
+        val ident: String
 )

--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/pdl/PdlResponses.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/pdl/PdlResponses.kt
@@ -1,7 +1,5 @@
 package no.nav.helse.arbeidsgiver.integrasjoner.pdl
 
-import java.io.Serializable
-
 data class PdlPersonResponse(
         val errors: List<PdlError>?,
         val data: PdlHentPerson?
@@ -26,13 +24,22 @@ data class PdlErrorExtension(
 
 data class PdlHentPerson(
         val hentPerson: PdlPerson?
-) : Serializable
+)
 
 data class PdlPerson(
-        val navn: List<PdlPersonNavn>) : Serializable
+        val navn: List<PdlPersonNavn>
+)
 
 data class PdlPersonNavn(
         val fornavn: String,
         val mellomnavn: String?,
-        val etternavn: String
-) : Serializable
+        val etternavn: String,
+        val metadata: PdlPersonNavnMetadata
+)
+
+data class PdlPersonNavnMetadata(
+        /**
+         * Inneholder "Freg" dersom "eieren" av informasjonen er folkeregisteret
+         */
+        val master: String
+)

--- a/src/main/resources/pdl/hentPerson.graphql
+++ b/src/main/resources/pdl/hentPerson.graphql
@@ -1,1 +1,0 @@
-query($ident: ID!, $navnHistorikk: Boolean!){hentPerson(ident: $ident) { navn(historikk: $navnHistorikk) { fornavn mellomnavn etternavn forkortetNavn originaltNavn { fornavn mellomnavn etternavn } } } }

--- a/src/main/resources/pdl/hentPersonNavn.graphql
+++ b/src/main/resources/pdl/hentPersonNavn.graphql
@@ -1,0 +1,8 @@
+query($ident: ID!) {
+    hentPerson(ident: $ident) {
+        navn {
+            fornavn mellomnavn etternavn forkortetNavn
+            folkeregistermetadata { kilde }
+        }
+    }
+}

--- a/src/main/resources/pdl/pdl-schema.graphql
+++ b/src/main/resources/pdl/pdl-schema.graphql
@@ -1,0 +1,660 @@
+#Fra https://raw.githubusercontent.com/navikt/pdl/master/apps/api/src/main/resources/schemas/pdl.graphqls
+
+
+# ISO-8601 representasjon for en kalenderdato. YYYY-MM-DD. Eksempel: 2018-01-01.
+scalar Date
+
+# ISO-8601 representasjon for en kalenderdato med tid, trunkert til nærmeste sekund. YYYY-MM-DD'T'hh:mm:ss. Eksempel: 2018-01-01T12:00:00.
+scalar DateTime
+
+# Schema parser kjenner ikke til Typen long  men den er støttet av graphql-java, så definerer den her for at schema skal validere.
+scalar Long
+
+schema {
+    query: Query
+}
+
+type Query {
+    hentPerson(ident: ID!): Person
+    hentPersonBolk(identer: [ID!]!): [HentPersonBolkResult!]!
+    hentIdenter(ident: ID!, grupper: [IdentGruppe!], historikk: Boolean = false): Identliste
+    hentIdenterBolk(identer: [ID!]!, grupper: [IdentGruppe!], historikk: Boolean = false): [HentIdenterBolkResult!]!
+    sokPerson(criteria:[Criterion], paging:Paging): SearchResult
+}
+
+type Identliste {
+    identer: [IdentInformasjon!]!
+}
+
+type HentIdenterBolkResult {
+    ident: String!
+    identer: [IdentInformasjon!]
+    code: String!
+}
+
+type IdentInformasjon {
+    ident: String!
+    gruppe: IdentGruppe!
+    historisk: Boolean!
+}
+
+enum IdentGruppe {
+    AKTORID,
+    FOLKEREGISTERIDENT,
+    NPID
+}
+
+type HentPersonBolkResult {
+    ident: String!
+    person: Person
+    code: String!
+}
+
+type Person {
+    adressebeskyttelse(historikk: Boolean = false): [Adressebeskyttelse!]!
+    bostedsadresse(historikk: Boolean = false): [Bostedsadresse!]!
+    deltBosted(historikk: Boolean = false): [DeltBosted!]!
+    doedfoedtBarn: [DoedfoedtBarn!]!
+    doedsfall: [Doedsfall!]!
+    falskIdentitet: FalskIdentitet
+    familierelasjoner: [Familierelasjon!]!
+    foedsel: [Foedsel!]!
+    folkeregisteridentifikator(historikk: Boolean = false): [Folkeregisteridentifikator!]!
+    folkeregisterpersonstatus(historikk: Boolean = false): [Folkeregisterpersonstatus!]!
+    foreldreansvar(historikk: Boolean = false): [Foreldreansvar!]!
+    fullmakt(historikk: Boolean = false): [Fullmakt!]!
+    identitetsgrunnlag(historikk: Boolean = false): [Identitetsgrunnlag!]!
+    kjoenn(historikk: Boolean = false): [Kjoenn!]!
+    kontaktadresse(historikk: Boolean = false): [Kontaktadresse!]!
+    kontaktinformasjonForDoedsbo(historikk: Boolean = false): [KontaktinformasjonForDoedsbo!]!
+    navn(historikk: Boolean = false): [Navn!]!
+    opphold(historikk: Boolean = false):[Opphold!]!
+    oppholdsadresse(historikk: Boolean = false):[Oppholdsadresse!]!
+    sikkerhetstiltak:[Sikkerhetstiltak!]!
+    sivilstand(historikk: Boolean = false):[Sivilstand!]!
+    statsborgerskap(historikk: Boolean = false): [Statsborgerskap!]!
+    telefonnummer: [Telefonnummer!]!
+    tilrettelagtKommunikasjon:[TilrettelagtKommunikasjon!]!
+    utenlandskIdentifikasjonsnummer(historikk: Boolean = false): [UtenlandskIdentifikasjonsnummer!]!
+    innflyttingTilNorge: [InnflyttingTilNorge!]!
+    utflyttingFraNorge: [UtflyttingFraNorge!]!
+    vergemaalEllerFremtidsfullmakt(historikk: Boolean = false): [VergemaalEllerFremtidsfullmakt!]!
+    geografiskTilknytning: GeografiskTilknytning
+}
+
+type DeltBosted {
+    startdatoForKontrakt: Date!
+    sluttdatoForKontrakt: Date
+    @deprecated(reason: "Flyttet til adresser rett under")
+    adresseNode: AdresseNode!
+
+    coAdressenavn: String
+    vegadresse: Vegadresse
+    matrikkeladresse: Matrikkeladresse
+    utenlandskAdresse: UtenlandskAdresse
+    ukjentBosted: UkjentBosted
+
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type Bostedsadresse {
+    angittFlyttedato: Date
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+
+    coAdressenavn: String
+    vegadresse: Vegadresse
+    matrikkeladresse: Matrikkeladresse
+    utenlandskAdresse: UtenlandskAdresse
+    ukjentBosted: UkjentBosted
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Oppholdsadresse {
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    oppholdsadressedato: Date @deprecated(reason: "Mappes til gyldigFraOgMed. Dette feltet er nå overflødig vil bli fjernet")
+
+    coAdressenavn: String
+    utenlandskAdresse: UtenlandskAdresse
+    vegadresse: Vegadresse
+    matrikkeladresse: Matrikkeladresse
+    oppholdAnnetSted: String
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Kontaktadresse {
+    gyldigFraOgMed: DateTime
+    gyldigTilOgMed: DateTime
+    type: KontaktadresseType!
+
+    coAdressenavn: String
+    postboksadresse: Postboksadresse
+    vegadresse: Vegadresse
+    postadresseIFrittFormat: PostadresseIFrittFormat
+    utenlandskAdresse: UtenlandskAdresse
+    utenlandskAdresseIFrittFormat: UtenlandskAdresseIFrittFormat
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+enum KontaktadresseType {
+    Innland,
+    Utland
+}
+
+type Vegadresse {
+    matrikkelId: Long
+    husnummer: String
+    husbokstav: String
+    bruksenhetsnummer: String
+    adressenavn: String
+    kommunenummer: String
+    bydelsnummer: String
+    tilleggsnavn: String
+    postnummer: String
+    koordinater: Koordinater
+}
+
+type Matrikkeladresse {
+    matrikkelId: Long
+    bruksenhetsnummer: String
+    tilleggsnavn: String
+    postnummer: String
+    kommunenummer: String
+    koordinater: Koordinater
+}
+
+type UkjentBosted {
+    bostedskommune: String
+}
+
+type UtenlandskAdresse {
+    adressenavnNummer: String
+    bygningEtasjeLeilighet: String
+    postboksNummerNavn: String
+    postkode: String
+    bySted: String
+    regionDistriktOmraade: String
+    landkode: String!
+}
+
+type UtenlandskAdresseIFrittFormat {
+    adresselinje1: String
+    adresselinje2: String
+    adresselinje3: String
+    postkode: String
+    byEllerStedsnavn: String
+    landkode: String!
+}
+
+type Postboksadresse {
+    postbokseier: String
+    postboks: String!
+    postnummer: String
+}
+
+type PostadresseIFrittFormat {
+    adresselinje1: String
+    adresselinje2: String
+    adresselinje3: String
+    postnummer: String
+}
+
+type Koordinater {
+    x: Float
+    y: Float
+    z: Float
+    kvalitet: Int
+}
+
+type AdresseNode {
+    coAdressenavn: String
+    adressegradering: String
+}
+
+type FalskIdentitet {
+    erFalsk: Boolean!
+    rettIdentitetVedIdentifikasjonsnummer: String
+    rettIdentitetErUkjent: Boolean
+    rettIdentitetVedOpplysninger: FalskIdentitetIdentifiserendeInformasjon
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type FalskIdentitetIdentifiserendeInformasjon {
+    personnavn: Personnavn!
+    foedselsdato: Date
+    statsborgerskap: [String!]!
+    kjoenn: KjoennType
+}
+
+type KontaktinformasjonForDoedsbo {
+    skifteform: KontaktinformasjonForDoedsboSkifteform!
+    attestutstedelsesdato: Date!
+    personSomKontakt: KontaktinformasjonForDoedsboPersonSomKontakt
+    advokatSomKontakt: KontaktinformasjonForDoedsboAdvokatSomKontakt
+    organisasjonSomKontakt: KontaktinformasjonForDoedsboOrganisasjonSomKontakt
+    adresse: KontaktinformasjonForDoedsboAdresse!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum KontaktinformasjonForDoedsboSkifteform {
+    OFFENTLIG
+    ANNET
+}
+
+type KontaktinformasjonForDoedsboPersonSomKontakt {
+    foedselsdato: Date
+    personnavn: Personnavn
+    identifikasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboAdvokatSomKontakt {
+    personnavn: Personnavn!
+    organisasjonsnavn: String
+    organisasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboOrganisasjonSomKontakt {
+    kontaktperson: Personnavn
+    organisasjonsnavn: String!
+    organisasjonsnummer: String
+}
+
+type KontaktinformasjonForDoedsboAdresse {
+    adresselinje1: String!
+    adresselinje2: String
+    poststedsnavn: String!
+    postnummer: String!
+    landkode: String
+}
+
+type UtenlandskIdentifikasjonsnummer {
+    identifikasjonsnummer: String!
+    utstederland: String!
+    opphoert: Boolean!
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Adressebeskyttelse {
+    gradering: AdressebeskyttelseGradering!
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+enum AdressebeskyttelseGradering {
+    STRENGT_FORTROLIG_UTLAND,
+    STRENGT_FORTROLIG,
+    FORTROLIG,
+    UGRADERT
+}
+
+type Foedsel {
+    foedselsaar: Int
+    foedselsdato: Date
+    foedeland: String
+    foedested: String
+    foedekommune: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Kjoenn {
+    kjoenn: KjoennType
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Doedsfall {
+    doedsdato: Date
+    metadata: Metadata!
+    folkeregistermetadata: Folkeregistermetadata
+}
+
+type Familierelasjon {
+    relatertPersonsIdent: String!
+    relatertPersonsRolle: Familierelasjonsrolle!
+    minRolleForPerson: Familierelasjonsrolle
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type DoedfoedtBarn {
+    dato: Date
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum Familierelasjonsrolle {
+    BARN,
+    MOR,
+    FAR,
+    MEDMOR
+}
+
+type Folkeregisterpersonstatus {
+    status: String!
+    forenkletStatus: String!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type GeografiskTilknytning {
+    gtType: GtType!
+    gtKommune: String
+    gtBydel: String
+    gtLand: String
+    metadata: Metadata!
+}
+
+enum GtType {
+    KOMMUNE,
+    BYDEL,
+    UTLAND,
+    UDEFINERT
+}
+
+type Navn {
+    fornavn: String!
+    mellomnavn: String
+    etternavn: String!
+    forkortetNavn: String
+    originaltNavn: OriginaltNavn
+    gyldigFraOgMed: Date
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type OriginaltNavn {
+    fornavn: String
+    mellomnavn: String
+    etternavn: String
+}
+
+type Personnavn {
+    fornavn: String!
+    mellomnavn: String
+    etternavn: String!
+}
+
+enum KjoennType {
+    MANN, KVINNE, UKJENT
+}
+
+type Identitetsgrunnlag {
+    status: Identitetsgrunnlagsstatus!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum Identitetsgrunnlagsstatus {
+    IKKE_KONTROLLERT
+    KONTROLLERT,
+    INGEN_STATUS
+}
+
+type Folkeregistermetadata {
+    ajourholdstidspunkt: DateTime
+    gyldighetstidspunkt: DateTime
+    opphoerstidspunkt: DateTime
+    kilde: String
+    aarsak: String
+    sekvens: Int
+}
+
+type Telefonnummer {
+    landskode: String!
+    nummer: String!
+    prioritet: Int!
+    metadata: Metadata!
+}
+
+type TilrettelagtKommunikasjon {
+    talespraaktolk: Tolk
+    tegnspraaktolk: Tolk
+    metadata: Metadata!
+}
+
+type Tolk {
+    spraak: String
+}
+
+enum FullmaktsRolle {
+    FULLMAKTSGIVER,
+    FULLMEKTIG
+}
+
+type Fullmakt {
+    motpartsPersonident: String!
+    motpartsRolle: FullmaktsRolle!
+    omraader: [String!]!
+    gyldigFraOgMed: Date!
+    gyldigTilOgMed: Date!
+    metadata: Metadata!
+}
+
+type Folkeregisteridentifikator {
+    identifikasjonsnummer: String!
+    status: String!
+    type: String!
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+type SikkerhetstiltakKontaktperson {
+    personident: String!
+    enhet: String!
+}
+
+type Sikkerhetstiltak {
+    tiltakstype: String!
+    beskrivelse: String!
+    kontaktperson: SikkerhetstiltakKontaktperson
+    gyldigFraOgMed: Date!
+    gyldigTilOgMed: Date!
+    metadata: Metadata!
+}
+
+type Statsborgerskap {
+    land: String!
+    gyldigFraOgMed: Date
+    gyldigTilOgMed: Date
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Opphold {
+    type: Oppholdstillatelse!
+    oppholdFra: Date
+    oppholdTil: Date
+    folkeregistermetadata: Folkeregistermetadata!
+    metadata: Metadata!
+}
+
+enum Oppholdstillatelse {
+    MIDLERTIDIG
+    PERMANENT
+    OPPLYSNING_MANGLER
+}
+
+type Sivilstand {
+    type: Sivilstandstype!
+    gyldigFraOgMed: Date
+    myndighet: String
+    kommune: String
+    sted: String
+    utland: String
+    relatertVedSivilstand: String
+    bekreftelsesdato: String
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+enum Sivilstandstype {
+    UOPPGITT
+    UGIFT
+    GIFT
+    ENKE_ELLER_ENKEMANN
+    SKILT
+    SEPARERT
+    REGISTRERT_PARTNER
+    SEPARERT_PARTNER
+    SKILT_PARTNER
+    GJENLEVENDE_PARTNER
+}
+
+type InnflyttingTilNorge {
+    fraflyttingsland: String
+    fraflyttingsstedIUtlandet: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type UtflyttingFraNorge {
+    tilflyttingsland: String
+    tilflyttingsstedIUtlandet: String
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type VergeEllerFullmektig {
+    navn: Personnavn
+    motpartsPersonident: String
+    omfang: String
+    omfangetErInnenPersonligOmraade: Boolean!
+}
+
+type VergemaalEllerFremtidsfullmakt {
+    type: String
+    embete: String
+    vergeEllerFullmektig: VergeEllerFullmektig!
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type Foreldreansvar {
+    ansvar: String
+    ansvarlig: String
+    ansvarligUtenIdentifikator: RelatertBiPerson
+
+    folkeregistermetadata: Folkeregistermetadata
+    metadata: Metadata!
+}
+
+type RelatertBiPerson {
+    navn: Personnavn
+    foedselsdato: Date
+    statsborgerskap: String
+    kjoenn: KjoennType
+}
+
+type Metadata {
+    # I PDL så får alle forekomster av en opplysning en ID som representerer dens unike forekomst.
+    # F.eks, så vil en Opprett ha ID X, korriger ID Y (der hvor den spesifiserer at den korrigerer X).
+    # Dersom en opplysning ikke er lagret i PDL, så vil denne verdien ikke være utfylt.
+    opplysningsId: String
+
+    # Master refererer til hvem som eier opplysningen, f.eks så har PDL en kopi av Folkeregisteret, da vil master være FREG og eventuelle endringer på dette må gå via Folkeregisteret (API mot dem eller andre rutiner).
+    master: String!
+
+    # En liste over alle endringer som har blitt utført over tid.
+    # Vær obs på at denne kan endre seg og man burde takle at det finnes flere korrigeringer i listen, så dersom man ønsker å kun vise den siste, så må man selv filtrere ut dette.
+    # Det kan også ved svært få tilfeller skje at opprett blir fjernet. F.eks ved splitt tilfeller av identer. Dette skal skje i svært få tilfeller. Dersom man ønsker å presentere opprettet tidspunktet, så blir det tidspunktet på den første endringen.
+    endringer: [Endring!]!
+
+    # Feltet betegner hvorvidt dette er en funksjonelt historisk opplysning, for eksempel en tidligere fraflyttet adresse eller et foreldreansvar som er utløpt fordi barnet har fylt 18 år.
+    # I de fleste tilfeller kan dette utledes ved å se på de andre feltene i opplysningen. Dette er imidlertid ikke alltid tilfellet, blant annet for foreldreansvar.
+    # Feltet bør brukes av konsumenter som henter informasjon fra GraphQL med historikk, men som også trenger å utlede gjeldende informasjon.
+    historisk: Boolean!
+}
+
+# Endring som har blitt utført på opplysningen. F.eks: Opprett -> Korriger -> Korriger
+type Endring {
+    # Hvilke type endring som har blitt utført.
+    type: Endringstype!
+    # Tidspunktet for registrering.
+    registrert: DateTime!
+    # Hvem endringen har blitt utført av, ofte saksbehandler (f.eks Z990200), men kan også være system (f.eks srvXXXX). Denne blir satt til "Folkeregisteret" for det vi får fra dem.
+    registrertAv: String!
+    # Hvilke system endringen har kommet fra (f.eks srvXXX). Denne blir satt til "FREG" for det vi får fra Folkeregisteret.
+    systemkilde: String!
+    # Opphavet til informasjonen. I NAV blir dette satt i forbindelse med registrering (f.eks: Sykehuskassan).
+    # Fra Folkeregisteret får vi opphaven til dems opplysning, altså NAV, UDI, Politiet, Skatteetaten o.l.. Fra Folkeregisteret kan det også være tekniske navn som: DSF_MIGRERING, m.m..
+    kilde: String!
+}
+
+enum Endringstype {
+    OPPRETT
+    KORRIGER
+    OPPHOER
+}
+
+input Criterion {
+    fieldName:String!
+    searchRule:SearchRule!
+    searchHistorical:Boolean
+}
+
+input SearchRule {
+    exists:String,
+    notEquals:String,
+    equals:String,
+    contains:String,
+    fuzzy:String,
+    wildcard:String,
+    startsWith:String,
+    regex:String,
+    after:String,
+    before:String,
+    lessThan:String,
+    greaterThan:String,
+    from:String,
+    to:String,
+    fromExcluding:String,
+    toExcluding:String,
+
+    #extra query parameters (can not be used as queries by them self)
+    caseSensitive:Boolean,
+    disablePhonetic:Boolean,
+    boost:Float
+}
+
+input Paging {
+    pageNumber:Int = 1,
+    resultsPerPage:Int = 10,
+    sortBy:[SearchSorting]
+}
+
+input SearchSorting {
+    fieldName:String!
+    direction:Direction!
+}
+enum Direction {
+    ASC,
+    DESC
+}
+type SearchResult {
+    hits : [searchHit!]!,
+    pageNumber:Int,
+    totalPages:Int
+    totalHits:Int
+
+}
+type searchHit {
+    person :Person,
+    identer(historikk: Boolean = false): [IdentInformasjon!]!,
+    score :Float
+}

--- a/src/test/kotlin/no/nav/helse/slowtests/TestUtils.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/TestUtils.kt
@@ -1,0 +1,48 @@
+package no.nav.helse.slowtests
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import io.ktor.client.*
+import io.ktor.client.engine.apache.*
+import io.ktor.client.features.json.*
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier
+import org.apache.http.conn.ssl.NoopHostnameVerifier
+
+object TestUtils {
+    fun commonObjectMapper() : ObjectMapper {
+        val om = ObjectMapper()
+        om.registerModule(KotlinModule())
+        om.registerModule(Jdk8Module())
+        om.registerModule(JavaTimeModule())
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        om.configure(SerializationFeature.INDENT_OUTPUT, true)
+        om.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+        return om
+    }
+
+    fun commonHttpClient() = HttpClient(Apache) {
+
+        this.engine {
+            this.customizeClient {
+                this.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+            }
+        }
+
+        install(JsonFeature) {
+                serializer = JacksonSerializer {
+                    registerModule(KotlinModule())
+                    registerModule(Jdk8Module())
+                    registerModule(JavaTimeModule())
+                    disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                    configure(SerializationFeature.INDENT_OUTPUT, true)
+                    configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+                }
+            }
+        }
+}

--- a/src/test/kotlin/no/nav/helse/slowtests/bakgrunnsjobb/PostgresBakgrunnsjobbRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/bakgrunnsjobb/PostgresBakgrunnsjobbRepositoryTest.kt
@@ -1,4 +1,4 @@
-package no.nav.helse.slowtests.arbeidsgiver.bakgrunnsjobb
+package no.nav.helse.slowtests.bakgrunnsjobb
 
 import com.zaxxer.hikari.HikariDataSource
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.Bakgrunnsjobb

--- a/src/test/kotlin/no/nav/helse/slowtests/integrasjoner/pdl/PdlClientImplIntegrationTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/integrasjoner/pdl/PdlClientImplIntegrationTests.kt
@@ -1,0 +1,43 @@
+package no.nav.helse.slowtests.integrasjoner.pdl
+
+import no.nav.helse.arbeidsgiver.integrasjoner.RestStsClient
+import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClientImpl
+import no.nav.helse.slowtests.TestUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+/**
+ * Utforskningstestet ment for å kjøres mot faktisk PDL i Q på lokal maskin via NaisDevice.
+ *
+ * For å kjøre denne må du hente ut et STS token (access_token verdien) i VMWare ved å
+ * bruke servicebrukeren og passordet til appen du tester for.
+ *
+ * Dette kan gjøres via curl:
+ *
+ * curl -X GET "https://security-token-service.nais.preprod.local/rest/v1/sts/token?grant_type=client_credentials&scope=openid" -H  "accept: application/json" --user srvusername:srvPASSWORD --insecure
+ *
+ * Servicebrukerens passord finner du i vault.
+ *
+ *
+ * NB!! Ikke sjekk inn passord eller Tokens i Git.
+ *
+ */
+@Disabled
+internal class PdlClientImplIntegrationTests {
+
+    val pdlKlient = PdlClientImpl(
+            "https://pdl-api.dev-fss.nais.io/graphql",
+            object: RestStsClient {
+                override fun getOidcToken() = "" // Sett inn token fra STS
+            },
+            TestUtils.commonHttpClient(),
+            TestUtils.commonObjectMapper()
+    )
+
+    @Test
+    internal fun invokePersonName() {
+        val person = pdlKlient.person("09077729434")
+        assertThat(person).isNotNull()
+    }
+}

--- a/src/test/resources/pdl-mock-data/pdl-hentIdenter-response.json
+++ b/src/test/resources/pdl-mock-data/pdl-hentIdenter-response.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "hentIdenter": {
+      "identer": [
+        {
+          "ident": "16047439276",
+          "gruppe": "FOLKEREGISTERIDENT"
+        },
+        {
+          "ident": "9916047439276",
+          "gruppe": "AKTORID"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/pdl-mock-data/pdl-person-response.json
+++ b/src/test/resources/pdl-mock-data/pdl-person-response.json
@@ -4,7 +4,10 @@
           "navn": [{
             "fornavn": "Ola",
             "mellomnavn": "",
-            "etternavn": "Norrbagg"
+            "etternavn": "Norrbagg",
+            "metadata": {
+              "master": "Freg"
+            }
           }]
         }
 },


### PR DESCRIPTION
- Legger til en utforskningstest man kan bruke for å teste mot PDL i Q på egen maskin
- Det er nå mulig å vite "hvem" som er eieren av navnet man slår opp fra PDL
ved å inspisere metadata->master.
- Fjerner ubrukte felter.