### PR TITLE
Ikke varsle at RestSTSAccessTokenProvider er deprecated

### DIFF
--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/AccessTokenProviders.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/integrasjoner/AccessTokenProviders.kt
@@ -21,8 +21,9 @@ interface AccessTokenProvider {
  * Det returnerte tokenet representerer den angitte servicebrukeren (username, password)
  *
  * Cacher tokenet til det 5 minutter unna å bli ugyldig.
+ *
+ * STS skal fases ut til fordel for OAuth2 Client Credentials og Token Exchange (TokenX)
  */
-@Deprecated("STS skal fases ut til fordel for OAuth2 Client Credentials og Token Exchange (TokenX)")
 class RestSTSAccessTokenProvider(
     username: String,
     password: String,


### PR DESCRIPTION
Når denne er på skrives det ut hundrevis av varsler som drukner alle andre nyttige meldinger