### PR TITLE
Deprecate funksjoner som kan erstattes via helsearbeidsgiver-utils

### DIFF
--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/utils/LogUtils.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/utils/LogUtils.kt
@@ -3,5 +3,6 @@ package no.nav.helse.arbeidsgiver.utils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+@Deprecated("Bruk samme metode fra https://github.com/navikt/helsearbeidsgiver-utils")
 fun <T : Any> T.logger(): Logger =
     LoggerFactory.getLogger(this.javaClass)

--- a/src/main/kotlin/no/nav/helse/arbeidsgiver/utils/SimpleHashMapCache.kt
+++ b/src/main/kotlin/no/nav/helse/arbeidsgiver/utils/SimpleHashMapCache.kt
@@ -4,6 +4,7 @@ import no.nav.helse.arbeidsgiver.system.TimeProvider
 import java.time.Duration
 import java.time.LocalDateTime
 
+@Deprecated("Bruk LocalCache fra https://github.com/navikt/helsearbeidsgiver-utils")
 class SimpleHashMapCache<T>(
     private val cacheDuration: Duration,
     private val maxCachedItems: Int,


### PR DESCRIPTION
Gjør dette i første omgang. Senere kan de fjernes helt.